### PR TITLE
feat: newsletter subscription section (closes #70)

### DIFF
--- a/src/utils/featureVisibility.ts
+++ b/src/utils/featureVisibility.ts
@@ -32,9 +32,6 @@ export const envGroups = {
  * Specify an array of environments where each feature should be visible
  */
 export const features = {
-  /** Newsletter subscription demo toggle in footer */
-  newsletterDemoToggle: envGroups.nonProduction,
-
   /** Authenticated user menu (avatar, tokens, dropdown) */
   authenticatedUserMenu: envGroups.localAndDev,
 

--- a/src/views/components/layout/NewsletterSection.tsx
+++ b/src/views/components/layout/NewsletterSection.tsx
@@ -8,9 +8,7 @@ import { communicationHooks } from "src/api";
 import { useZodForm, Form, RhfFormInput } from "src/views/components/ui/forms/rhf";
 import { newsletterFormSchema, type NewsletterFormData } from "src/views/components/ui/forms/schemas";
 
-interface NewsletterSectionProps {}
-
-export function NewsletterSection(_props: NewsletterSectionProps) {
+export function NewsletterSection() {
   const [isSuccess, setIsSuccess] = useState(false);
 
   const form = useZodForm(newsletterFormSchema, {
@@ -67,14 +65,7 @@ export function NewsletterSection(_props: NewsletterSectionProps) {
         {/* Error State */}
         {error && (
           <div className="mb-4">
-            <ServerErrorAlert
-              variant="compact"
-              message={
-                error.message || "Subscription failed. Please try again later or contact support@opensourceeconomy.org"
-              }
-              showDismiss
-              onDismiss={handleErrorDismiss}
-            />
+            <ServerErrorAlert variant="compact" error={error} showDismiss onDismiss={handleErrorDismiss} />
           </div>
         )}
 


### PR DESCRIPTION
Closes #70. Supersedes #71 (which targets an outdated codebase — `src/ultils/`, `handleApiCall`, `getBackendAPI()`, `validateEmail` — and no longer applies cleanly).

## What

Finalizes the newsletter subscription section as a dedicated component, wired to the real API, matching the Figma design in `Open-Source-Economy/figma-frontend` (`Footer.tsx` → Newsletter Section).

## Changes

- **`NewsletterSection.tsx`** — dedicated component extracted from `Footer.tsx`:
  - RHF + Zod (`emailSchema`) validation with inline errors
  - Submits via `communicationService.subscribeToNewsletter` (`POST /newsletter`) through `communicationHooks`
  - Loading (button spinner + "Subscribing…"), success banner + "Subscribe Another Email", and `ServerErrorAlert` on failure
  - Uses `ServerErrorAlert` `error=` prop (not deprecated `message=`); dropped empty props interface
- **`featureVisibility.ts`** — removed unused `newsletterDemoToggle` flag (PR #71 review comment)
- Intentionally omits the Figma file's dev-only scaffolding (`StateTestingWrapper`, "Demo Mode" toggle, standalone loading `Alert` box) — exactly the cleanup requested in the PR #71 review (input no longer "jumps").

## Acceptance criteria (#70)

- [x] Enter email and submit
- [x] Email validated before submission (Zod via RHF)
- [x] Submits to the newsletter endpoint
- [x] Visible loading state
- [x] Success + error user feedback
- [x] Logic moved out of `Footer.tsx`

## Verification

- `tsc --noEmit`: no errors in changed files
- `eslint`: clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)