### PR TITLE
feat: add Imprint (Impressum) page (closes #51)

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as ProjectItemsDetailsRouteImport } from "./routes/project-items-
 import { Route as PrivacyRouteImport } from "./routes/privacy"
 import { Route as PricingRouteImport } from "./routes/pricing"
 import { Route as LogoutRouteImport } from "./routes/logout"
+import { Route as ImprintRouteImport } from "./routes/imprint"
 import { Route as FaqRouteImport } from "./routes/faq"
 import { Route as DeveloperRouteImport } from "./routes/developer"
 import { Route as ContactRouteImport } from "./routes/contact"
@@ -85,6 +86,11 @@ const PricingRoute = PricingRouteImport.update({
 const LogoutRoute = LogoutRouteImport.update({
   id: "/logout",
   path: "/logout",
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ImprintRoute = ImprintRouteImport.update({
+  id: "/imprint",
+  path: "/imprint",
   getParentRoute: () => rootRouteImport,
 } as any)
 const FaqRoute = FaqRouteImport.update({
@@ -246,6 +252,7 @@ export interface FileRoutesByFullPath {
   "/contact": typeof ContactRoute
   "/developer": typeof DeveloperRoute
   "/faq": typeof FaqRoute
+  "/imprint": typeof ImprintRoute
   "/logout": typeof LogoutRoute
   "/pricing": typeof PricingRoute
   "/privacy": typeof PrivacyRoute
@@ -283,6 +290,7 @@ export interface FileRoutesByTo {
   "/contact": typeof ContactRoute
   "/developer": typeof DeveloperRoute
   "/faq": typeof FaqRoute
+  "/imprint": typeof ImprintRoute
   "/logout": typeof LogoutRoute
   "/pricing": typeof PricingRoute
   "/privacy": typeof PrivacyRoute
@@ -323,6 +331,7 @@ export interface FileRoutesById {
   "/contact": typeof ContactRoute
   "/developer": typeof DeveloperRoute
   "/faq": typeof FaqRoute
+  "/imprint": typeof ImprintRoute
   "/logout": typeof LogoutRoute
   "/pricing": typeof PricingRoute
   "/privacy": typeof PrivacyRoute
@@ -363,6 +372,7 @@ export interface FileRouteTypes {
     | "/contact"
     | "/developer"
     | "/faq"
+    | "/imprint"
     | "/logout"
     | "/pricing"
     | "/privacy"
@@ -400,6 +410,7 @@ export interface FileRouteTypes {
     | "/contact"
     | "/developer"
     | "/faq"
+    | "/imprint"
     | "/logout"
     | "/pricing"
     | "/privacy"
@@ -439,6 +450,7 @@ export interface FileRouteTypes {
     | "/contact"
     | "/developer"
     | "/faq"
+    | "/imprint"
     | "/logout"
     | "/pricing"
     | "/privacy"
@@ -479,6 +491,7 @@ export interface RootRouteChildren {
   ContactRoute: typeof ContactRoute
   DeveloperRoute: typeof DeveloperRoute
   FaqRoute: typeof FaqRoute
+  ImprintRoute: typeof ImprintRoute
   LogoutRoute: typeof LogoutRoute
   PricingRoute: typeof PricingRoute
   PrivacyRoute: typeof PrivacyRoute
@@ -553,6 +566,13 @@ declare module "@tanstack/react-router" {
       path: "/logout"
       fullPath: "/logout"
       preLoaderRoute: typeof LogoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/imprint": {
+      id: "/imprint"
+      path: "/imprint"
+      fullPath: "/imprint"
+      preLoaderRoute: typeof ImprintRouteImport
       parentRoute: typeof rootRouteImport
     }
     "/faq": {
@@ -818,6 +838,7 @@ const rootRouteChildren: RootRouteChildren = {
   ContactRoute: ContactRoute,
   DeveloperRoute: DeveloperRoute,
   FaqRoute: FaqRoute,
+  ImprintRoute: ImprintRoute,
   LogoutRoute: LogoutRoute,
   PricingRoute: PricingRoute,
   PrivacyRoute: PrivacyRoute,

--- a/src/routes/imprint.tsx
+++ b/src/routes/imprint.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ImprintPage } from "src/views/pages/ImprintPage";
+
+export const Route = createFileRoute("/imprint")({
+  component: ImprintPage,
+});

--- a/src/views/components/layout/navigation.tsx
+++ b/src/views/components/layout/navigation.tsx
@@ -40,6 +40,7 @@ export const navigationLinks = {
     icon: <BookOpen className="w-4 h-4" />,
   } as NavigationLink,
   contact: { title: "Contact", href: "/contact", icon: <Mail className="w-4 h-4" /> } as NavigationLink,
+  imprint: { title: "Imprint", href: "/imprint", icon: <FileText className="w-4 h-4" /> } as NavigationLink,
   support: { title: "Support", href: "/sponsorship", icon: <LifeBuoy className="w-4 h-4" /> } as NavigationLink,
   login: { title: "Log In", href: "/auth/identify", icon: <LogIn className="w-4 h-4" /> } as NavigationLink,
 
@@ -137,6 +138,7 @@ export const footerNavigation = {
       title: "Company",
       links: [
         navigationLinks.contact,
+        navigationLinks.imprint,
         // navigationLinks.about,
         // navigationLinks.privacy,
       ],

--- a/src/views/pages/ImprintPage.tsx
+++ b/src/views/pages/ImprintPage.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { Building2, FileText, Mail, Scale } from "lucide-react";
+import { PageWrapper } from "src/views/pages/PageWrapper";
+import { ExternalLink } from "src/views/components/ui/forms/external-link";
+import { externalLinks } from "src/externalLinks";
+import { contactEmail } from "src/views/v1/data";
+
+export function ImprintPage() {
+  return (
+    <PageWrapper>
+      <div className="min-h-screen bg-gradient-to-b from-brand-secondary via-brand-neutral-100 to-brand-secondary-dark">
+        {/* Hero Section */}
+        <section className="relative overflow-hidden bg-gradient-to-br from-brand-neutral-100 via-brand-secondary to-brand-card-blue pt-32 pb-20">
+          <div className="absolute top-0 right-1/4 w-96 h-96 bg-brand-accent/10 rounded-full blur-3xl opacity-40" />
+          <div className="absolute bottom-0 left-1/4 w-80 h-80 bg-brand-highlight/10 rounded-full blur-3xl opacity-30" />
+
+          <div className="container mx-auto px-6 relative z-10">
+            <div className="max-w-4xl mx-auto text-center">
+              <div className="inline-flex items-center gap-2 bg-brand-card-blue px-4 py-2 rounded-full mb-6 border border-brand-neutral-300">
+                <Scale className="w-4 h-4 text-brand-accent" />
+                <span className="text-brand-neutral-700">Legal Notice</span>
+              </div>
+
+              <h1 className="text-brand-neutral-950 mb-2">Imprint</h1>
+              <p className="text-brand-neutral-600 mb-6">(Impressum)</p>
+
+              <p className="text-brand-neutral-700 max-w-3xl mx-auto">
+                Legal information about the operator of this website, as required for visitors in Germany, the United
+                Kingdom, and other jurisdictions.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Content */}
+        <section className="py-20 bg-gradient-to-b from-brand-card-blue via-brand-secondary to-brand-neutral-100">
+          <div className="container mx-auto px-6">
+            <div className="max-w-4xl mx-auto space-y-16">
+              {/* Provider */}
+              <div className="space-y-6">
+                <div className="flex items-start gap-4">
+                  <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-brand-accent/10 flex items-center justify-center border border-brand-accent/20">
+                    <Building2 className="w-6 h-6 text-brand-accent" />
+                  </div>
+                  <div className="flex-1">
+                    <h2 className="text-brand-neutral-950 mb-4">Provider</h2>
+                    <div className="space-y-1 text-brand-neutral-700">
+                      <p className="text-brand-neutral-900">Open Source Economy</p>
+                      <p>Non-profit organisation</p>
+                      <p>Switzerland</p>
+                    </div>
+                  </div>
+                </div>
+                <div className="border-t border-brand-neutral-300 mt-8" />
+              </div>
+
+              {/* Commercial Register */}
+              <div className="space-y-6">
+                <div className="flex items-start gap-4">
+                  <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-brand-accent/10 flex items-center justify-center border border-brand-accent/20">
+                    <FileText className="w-6 h-6 text-brand-accent" />
+                  </div>
+                  <div className="flex-1">
+                    <h2 className="text-brand-neutral-950 mb-4">Commercial Register</h2>
+                    <div className="space-y-3 text-brand-neutral-700">
+                      <p>
+                        <span className="text-brand-neutral-800">Registration number:</span>{" "}
+                        <ExternalLink
+                          href={externalLinks.ZEFIX}
+                          className="text-brand-accent hover:text-brand-accent-dark transition-colors"
+                        >
+                          CHE-440.058.692
+                        </ExternalLink>
+                      </p>
+                      <p>
+                        The full official record is available on the Swiss commercial register (Zefix) via the link
+                        above.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div className="border-t border-brand-neutral-300 mt-8" />
+              </div>
+
+              {/* Contact */}
+              <div className="space-y-6">
+                <div className="flex items-start gap-4">
+                  <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-brand-accent/10 flex items-center justify-center border border-brand-accent/20">
+                    <Mail className="w-6 h-6 text-brand-accent" />
+                  </div>
+                  <div className="flex-1">
+                    <h2 className="text-brand-neutral-950 mb-4">Contact</h2>
+                    <p className="text-brand-neutral-700">
+                      <span className="text-brand-neutral-800">Email:</span>{" "}
+                      <a
+                        href={`mailto:${contactEmail}`}
+                        className="text-brand-accent hover:text-brand-accent-dark transition-colors"
+                      >
+                        {contactEmail}
+                      </a>
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </PageWrapper>
+  );
+}


### PR DESCRIPTION
Closes #51.

## What

Adds a dedicated **Imprint (Impressum)** legal-notice page at `/imprint`. An imprint is legally required for websites operating in Germany and the UK (and good practice elsewhere), as requested in the issue.

## Changes

- **`src/views/pages/ImprintPage.tsx`** (new) — legal-notice page with three sections:
  - **Provider**: Open Source Economy, non-profit organisation, Switzerland
  - **Commercial Register**: registration number `CHE-440.058.692`, linking to the Swiss commercial register (Zefix) for the full official record
  - **Contact**: contact email as a `mailto:` link (reuses the existing `contactEmail` constant)
- **`src/routes/imprint.tsx`** (new) — `/imprint` route (mirrors `src/routes/privacy.tsx`)
- **`src/views/components/layout/navigation.tsx`** — adds an **Imprint** link to the footer "Company" section via the navigation registry
- **`src/routeTree.gen.ts`** — regenerated by the TanStack Router plugin to include `/imprint`

## Design & content notes

- Built on the existing `PageWrapper` + `PrivacyPolicyPage` design system (hero + content sections + brand tokens) so it matches the current site. No dedicated Figma design exists for this page.
- The repo contains no postal address or named representative, so none is invented — the legally complete record is reachable via the linked Zefix registry entry. If a postal address/representative should be shown, it can be added later.
- No backend, no new data model — a self-contained static page.

## Verification

- `tsc --noEmit`: no errors in the new/changed files
- `eslint`: clean on the new/changed files
- Dev server: `/imprint` returns HTTP 200 and renders; footer "Company" → **Imprint** routes correctly; `CHE-440.058.692` opens the Zefix registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)